### PR TITLE
Fix container build by resolving conflict between nodejs and nsolid.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ USER root
 
 # Install Node.js 22 and nsolid for filesystem operations support
 RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
+    yum remove -y nodejs && \
     yum install -y nsolid && \
     yum clean all
 


### PR DESCRIPTION
The container build fails at nsolid installation because nodejs is already installed:

Error:
 Problem: problem with installed package nodejs-1:22.19.0-2.module+el9.7.0+23475+0a960596.x86_64
...
Error: building at STEP "RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && yum install -y nsolid && yum clean all": while running runtime: exit status 1

I assume we intentionally want to use NSolid as an alternative to nodejs. As both packages do not co-exist with each other, we need to remove nodejs before installing NSolid.